### PR TITLE
Fix/add provider

### DIFF
--- a/definition_generator/parse_prometheus/prometheus_processor.py
+++ b/definition_generator/parse_prometheus/prometheus_processor.py
@@ -5,7 +5,7 @@ import requests
 
 from prometheus_client.parser import text_string_to_metric_families
 
-RESERVED_NAMESPACE = []
+RESERVED_NAMESPACE = ["go", "process", "promhttp"]
 logger = logging.getLogger()
 
 
@@ -59,6 +59,7 @@ def getServiceObj(output, serviceName):
     logger.info("New service found: %s", serviceName)
     serviceObj={}
     output[serviceName] = serviceObj
+    serviceObj["provider"] = "prometheus"
     serviceObj["service"]=serviceName
     serviceObj["display_name"]=capitalise(serviceName)
     serviceObj["entities"]=[]

--- a/definitions/prometheus_exporters/prometheus_githubactions.yml
+++ b/definitions/prometheus_exporters/prometheus_githubactions.yml
@@ -3,6 +3,8 @@ service: github
 display_name: Github
 entities:
 - name: job
+  labels:
+  - id
   metrics:
   - provider_name: github_job
     description: job status
@@ -17,6 +19,8 @@ entities:
     - run_number
     - status
 - name: runner
+  labels:
+  - id
   metrics:
   - provider_name: github_runner_status
     description: runner status

--- a/definitions/prometheus_exporters/prometheus_githubactions.yml
+++ b/definitions/prometheus_exporters/prometheus_githubactions.yml
@@ -3,8 +3,9 @@ service: github
 display_name: Github
 entities:
 - name: job
-  labels:
-  - id
+  properties:
+    labels:
+    - id
   metrics:
   - provider_name: github_job
     description: job status
@@ -19,8 +20,9 @@ entities:
     - run_number
     - status
 - name: runner
-  labels:
-  - id
+  properties:
+    labels:
+    - id
   metrics:
   - provider_name: github_runner_status
     description: runner status

--- a/definitions/prometheus_exporters/prometheus_githubactions.yml
+++ b/definitions/prometheus_exporters/prometheus_githubactions.yml
@@ -1,0 +1,29 @@
+provider: prometheus
+service: github
+display_name: Github
+entities:
+- name: job
+  metrics:
+  - provider_name: github_job
+    description: job status
+    type: gauge
+    labels:
+    - event
+    - head_branch
+    - head_sha
+    - id
+    - node_id
+    - repo
+    - run_number
+    - status
+- name: runner
+  metrics:
+  - provider_name: github_runner_status
+    description: runner status
+    type: gauge
+    labels:
+    - id
+    - name
+    - os
+    - repo
+    - status

--- a/definitions/prometheus_exporters/prometheus_ravendb.yml
+++ b/definitions/prometheus_exporters/prometheus_ravendb.yml
@@ -1,5 +1,6 @@
 service: ravendb
 display_name: Ravendb
+provider: prometheus
 entities:
 - name: node
   metrics:


### PR DESCRIPTION
### Reason behind the change
I added back `provider key` since it is needed by the automation tool when generating the documentation to select the correct template.

The missing key was causing the tools to fail.


Moreover I added some reserved namespace and the `github action exporter` definition file